### PR TITLE
Escape spaces in wildignore

### DIFF
--- a/plugin/gitignore.vim
+++ b/plugin/gitignore.vim
@@ -43,7 +43,7 @@ function s:WildignoreFromGitignore(...)
       if line == ''   | con | endif
       if line =~ '^!' | con | endif
       if line =~ '/$' | let igstring .= "," . line . "*" | con | endif
-      let igstring .= "," . line
+      let igstring .= "," . substitute(line, ' ', '\\ ', "g")
     endfor
     let execstring = "set wildignore+=".substitute(igstring, '^,', '', "g")
     execute execstring


### PR DESCRIPTION
When there are entries with spaces in `.gitignore`, this plugin fails because it doesn't escape spaces properly in the `wildignore` call. This fixes that.
